### PR TITLE
Add option to use more complex python code as parameter value

### DIFF
--- a/jube2/util/util.py
+++ b/jube2/util/util.py
@@ -279,7 +279,15 @@ def convert_type(value_type, value, stop=True):
 def script_evaluation(cmd, script_type):
     """cmd will be evaluated with given script language"""
     if script_type == "python":
-        return str(eval(cmd))
+        if "return " not in cmd:
+            try:
+                return str(eval(cmd))
+            except:
+                pass
+        loc = {}
+        i = cmd.rfind("return ")
+        exec(cmd[:i] + cmd[i:].replace("return ", "return_value = "), globals(), loc)
+        return str(loc["return_value"])
     elif script_type in ["perl", "shell"]:
         if script_type == "perl":
             cmd = "perl -e \"print " + cmd + "\""


### PR DESCRIPTION
Currently, JUBE only allows parameters with the `mode` set to `python` to be simple expressions, which is quite restrictive.  
This PR adds the possibility for any arbitrary python code to be passed as a parameter value, which will then use the code's return value as parameter value.