### PR TITLE
Jobfile example always writes the done_file

### DIFF
--- a/examples/jobsystem/job.run.in
+++ b/examples/jobsystem/job.run.in
@@ -8,5 +8,11 @@
 
 ### start of jobscript
 
+# Always create the done_file at exit
+write_job_status()
+{
+  printf "$?" > #READY#
+}
+trap write_job_status EXIT
+
 #EXEC#
-touch #READY#


### PR DESCRIPTION
Ensure that the done_file is always written, even in case that the job script exits early with an error, for example due to time limit.

Also write the exit status to the done_file. This enables easy verification that all jobs completed successfully.